### PR TITLE
Fixed error response returned when Call fails.

### DIFF
--- a/scgapi/src/main/java/com/syniverse/scgapi/Session.java
+++ b/scgapi/src/main/java/com/syniverse/scgapi/Session.java
@@ -135,8 +135,12 @@ public class Session {
             // Auth error
             throw new Error.AuthError();
         }
-
-        throw new Error.ServerFailure(resp.code(), resp.errorBody().toString());
+        try {
+            final String reason = resp.errorBody().string();
+            throw new Error.ServerFailure(resp.code(), reason);
+        } catch (IOException ex) {
+            throw new Error.ServerFailure(resp.code(), resp.errorBody().toString());
+        }
     }
 
     interface CratingApiCallback {


### PR DESCRIPTION
Fixed error response returned when Call fails.
- The ok Http Call errors are not being correctly captured in the `ScgException`.
- Fixed the problem line to capture the correct data in the error.